### PR TITLE
fix: allow '-' in plugin name

### DIFF
--- a/src/anemoi/plugins/commands/new.py
+++ b/src/anemoi/plugins/commands/new.py
@@ -16,7 +16,7 @@ from anemoi.plugins.data import templates_directory
 from . import Command
 
 
-def camel_to_snake_case(val: str) -> str:
+def snake_to_camel_case(val: str) -> str:
     return "".join([word.capitalize() for word in val.split("_")])
 
 
@@ -145,7 +145,7 @@ class Create(Command):
 
         plugin_package = project_name.replace("-", "_")
         entry_point = ".".join(["anemoi", package, extended_kind]) + "s"
-        plugin_class = camel_to_snake_case(name) + "Plugin"
+        plugin_class = snake_to_camel_case(name) + "Plugin"
 
         settings: dict = dict(
             package=package,

--- a/src/anemoi/plugins/commands/new.py
+++ b/src/anemoi/plugins/commands/new.py
@@ -16,6 +16,10 @@ from anemoi.plugins.data import templates_directory
 from . import Command
 
 
+def camel_to_snake_case(val: str) -> str:
+    return "".join([word.capitalize() for word in val.split("_")])
+
+
 class Create(Command):
     """Create a new plugin."""
 
@@ -50,7 +54,13 @@ class Create(Command):
         packages = sorted(os.listdir(templates_directory))
         kinds = sorted([f"{p}.{k}" for p in packages for k in sorted(os.listdir(os.path.join(templates_directory, p)))])
 
-        command_parser.add_argument("plugin", type=str, help="The type of plugin", choices=kinds, metavar="PLUGIN")
+        command_parser.add_argument(
+            "plugin",
+            type=str,
+            help="The type of plugin",
+            choices=kinds,
+            metavar="PLUGIN",
+        )
 
         command_parser.add_argument("--name", type=str, help="The name of the plugin", default="example")
         command_parser.add_argument("--package", type=str, help="The package of the plugin")
@@ -89,14 +99,15 @@ class Create(Command):
         else:
             testing = "testing"
 
-        name = args.name
+        plugin_name = args.name
+        name = plugin_name.replace("-", "_")
 
         if args.package:
             project_name = args.package
             if "." in project_name:
                 raise ValueError(f"Invalid package name {project_name}")
         else:
-            project_name = f"anemoi-{package}-{extended_kind.replace('.','-')}-example-plugin"
+            project_name = f"anemoi-{package}-{extended_kind.replace('.', '-')}-example-plugin"
 
         if args.specialisation:
             self.specialisations.setdefault(args.plugin, defaultdict(list))
@@ -134,13 +145,14 @@ class Create(Command):
 
         plugin_package = project_name.replace("-", "_")
         entry_point = ".".join(["anemoi", package, extended_kind]) + "s"
-        plugin_class = name.capitalize() + "Plugin"
+        plugin_class = camel_to_snake_case(name) + "Plugin"
 
         settings: dict = dict(
             package=package,
             kind=kind,
             extended_kind=extended_kind,
             name=name,
+            plugin_name=plugin_name,
             project_name=project_name,
             plugin_package=plugin_package,
             entry_point=entry_point,
@@ -232,7 +244,6 @@ class Create(Command):
 
         for root, _, files in os.walk(source_directory):
             for file in files:
-
                 if "-" in file:
                     # Skip specialised files
                     continue

--- a/src/anemoi/plugins/data/common/pyproject.toml.mako
+++ b/src/anemoi/plugins/data/common/pyproject.toml.mako
@@ -36,4 +36,4 @@ classifiers = [
 
 urls.Homepage = "https://github.com/ecmwf/anemoi-plugins"
 
-entry-points."${entry_point}".${name} = "${plugin_package}.${name}:${plugin_class}"
+entry-points."${entry_point}".${plugin_name} = "${plugin_package}.${name}:${plugin_class}"

--- a/src/anemoi/plugins/data/common/tests/test_plugin.py.mako
+++ b/src/anemoi/plugins/data/common/tests/test_plugin.py.mako
@@ -3,7 +3,7 @@ from anemoi.${package}.${testing} import TestingContext
 
 
 def test_plugin():
-    ${kind} = create_${kind}(TestingContext(), "${name}")
+    ${kind} = create_${kind}(TestingContext(), "${plugin_name}")
     assert ${kind} is not None
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
allow '-' in plugin name

## What problem does this change solve?
Before, if the plugin name had a "-", the plugin class also had a "-" in the name, like:
```
class Foo-barPlugin(Source):
    ...
```

## What issue or task does this change relate to?
Fixes #13 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
